### PR TITLE
Fix bugs in reading Volume from flux data file and if user specifies TSKIP

### DIFF
--- a/thermocepstrum/analysis.py
+++ b/thermocepstrum/analysis.py
@@ -224,6 +224,8 @@ Contact: lercole@sissa.it
             selected_keys.append('Temp')
 #      if 'Press' in jfile.ckey:
 #         selected_keys.append('Press')
+        if volume is None and structurefile is None: # Noam Bernstein fix
+            selected_keys.append('Volume') # Noam Bernstein fix
         jfile = tc.i_o.TableFile(inputfile, group_vectors=True)
         jfile.read_datalines(start_step=START_STEP, NSTEPS=NSTEPS, select_ckeys=selected_keys)
         jdata = jfile.data
@@ -297,9 +299,11 @@ Contact: lercole@sissa.it
             log.write_log(' Volume (structure file):    {} A^3'.format(volume))
             logfile.write(' Volume (structure file):    {} A^3'.format(volume))
         elif 'Volume' in jdata:
-            volume = jdata['Volume']
+            volume = np.mean(jdata['Volume'])
             log.write_log(' Volume (file):    {} A^3'.format(volume))
             logfile.write(' Volume (file):    {} A^3\n'.format(volume))
+            if 'Volume' in selected_keys: # Noam Bernstein fix
+                selected_keys.remove('Volume') # Noam Bernstein fix
         else:
             raise RuntimeError('No Volume key found. Please provide Volume (-V) of structure file (--structure).')
     else:
@@ -392,6 +396,7 @@ Contact: lercole@sissa.it
         if resample:
             if TSKIP is not None:
                 jf, ax = tc.heatcurrent.resample_current(j, TSKIP=TSKIP, plot=True, PSD_FILTER_W=psd_filter_w)
+                FSTAR = j.Nyquist_f_THz / TSKIP # Noam Bernstein fix, copied from tc.heatcurrent.resample_current
             else:
                 jf, ax = tc.heatcurrent.resample_current(j, fstar_THz=FSTAR, plot=True, PSD_FILTER_W=psd_filter_w)
             ax[0].set_xlim([0, 2.5 * FSTAR])


### PR DESCRIPTION
A couple of little bug fixes I found as I was trying to use the command line interface (probably in a way different from that usually invoked), with Volume in the data file, and TSKIP rather than FSTAR.